### PR TITLE
Fix for autocomplete-values confusing things

### DIFF
--- a/fields/field.referencelink.php
+++ b/fields/field.referencelink.php
@@ -182,7 +182,7 @@
 		public function processRawFieldData($data, &$status, $simulate=false, $entry_id=NULL) {
 			$status = self::__OK__;
 
-			if(!is_array($data)) return array('relation_id' => $data);
+			if(!is_array($data)) return array('relation_id' => substr_replace($data, '', strrpos($data, ', '), strlen($data)));
 
 			if(empty($data)) return NULL;
 


### PR DESCRIPTION
This fix is a bit hard to explain...

It has to do with the [issue I raised](http://symphony-cms.com/download/extensions/issues/view/20523/2/). After investigating a bit I found out that the JS was appending that comma to the field value even if it wasn't set to accept multiple values. In this case the returned value was simply a string, with that comma. This threw off things in the system (such as the Reflection field) but somehow ended up working ok... until I noticed it.

However, it should be fixed now. :-)
