### PR TITLE
Mark the extension as deprecated

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension id="referencelink" status="released" xmlns="http://symphony-cms.com/schemas/extension/1.0">
+<extension id="referencelink" status="deprecated" xmlns="http://symphony-cms.com/schemas/extension/1.0">
 	<name>Field: Reference Link</name>
 	<description>Autocomplete select box links</description>
 	<repo type="github">https://github.com/czheng/referencelink</repo>


### PR DESCRIPTION
See https://github.com/symphonists/referencelink/issues/14 for details

@brendo Do I need to create a new version that explains why and to point to Select Box Link ?

cc  @nilshoerrmann @twiro @kmeinke
